### PR TITLE
Fix missing classes from jar files

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,19 +8,19 @@
         <outputRelativeToContentRoot value="true" />
         <module name="base" />
         <module name="fastutil-base" />
-        <module name="fastutil-floatbase" />
-        <module name="fastutil-floatcustomhashmap" />
-        <module name="fastutil-floathashmap" />
+        <module name="fastutil-booleanbase" />
         <module name="fastutil-bytebase" />
         <module name="fastutil-bytecustomhashmap" />
         <module name="fastutil-bytehashmap" />
-        <module name="fastutil-booleanbase" />
         <module name="fastutil-charbase" />
         <module name="fastutil-charcustomhashmap" />
         <module name="fastutil-charhashmap" />
         <module name="fastutil-doublebase" />
         <module name="fastutil-doublecustomhashmap" />
         <module name="fastutil-doublehashmap" />
+        <module name="fastutil-floatbase" />
+        <module name="fastutil-floatcustomhashmap" />
+        <module name="fastutil-floathashmap" />
         <module name="fastutil-intbase" />
         <module name="fastutil-intcustomhashmap" />
         <module name="fastutil-inthashmap" />
@@ -46,19 +46,19 @@
     <bytecodeTargetLevel>
       <module name="base" target="1.5" />
       <module name="fastutil-base" target="1.8" />
-      <module name="fastutil-floatbase" target="1.8" />
-      <module name="fastutil-floatcustomhashmap" target="1.8" />
-      <module name="fastutil-floathashmap" target="1.8" />
+      <module name="fastutil-booleanbase" target="1.8" />
       <module name="fastutil-bytebase" target="1.8" />
       <module name="fastutil-bytecustomhashmap" target="1.8" />
       <module name="fastutil-bytehashmap" target="1.8" />
-      <module name="fastutil-booleanbase" target="1.8" />
       <module name="fastutil-charbase" target="1.8" />
       <module name="fastutil-charcustomhashmap" target="1.8" />
       <module name="fastutil-charhashmap" target="1.8" />
       <module name="fastutil-doublebase" target="1.8" />
       <module name="fastutil-doublecustomhashmap" target="1.8" />
       <module name="fastutil-doublehashmap" target="1.8" />
+      <module name="fastutil-floatbase" target="1.8" />
+      <module name="fastutil-floatcustomhashmap" target="1.8" />
+      <module name="fastutil-floathashmap" target="1.8" />
       <module name="fastutil-intbase" target="1.8" />
       <module name="fastutil-intcustomhashmap" target="1.8" />
       <module name="fastutil-inthashmap" target="1.8" />
@@ -68,13 +68,13 @@
       <module name="fastutil-longcustomhashmap" target="1.8" />
       <module name="fastutil-longhashmap" target="1.8" />
       <module name="fastutil-longthashmap" target="1.8" />
-      <module name="fastutil-parent" target="1.8" />
-      <module name="fastutil-shortbase" target="1.8" />
-      <module name="fastutil-shortcustomhashmap" target="1.8" />
-      <module name="fastutil-shorthashmap" target="1.8" />
       <module name="fastutil-objectbase" target="1.8" />
       <module name="fastutil-objectcustomhashmap" target="1.8" />
       <module name="fastutil-objecthashmap" target="1.8" />
+      <module name="fastutil-parent" target="1.5" />
+      <module name="fastutil-shortbase" target="1.8" />
+      <module name="fastutil-shortcustomhashmap" target="1.8" />
+      <module name="fastutil-shorthashmap" target="1.8" />
       <module name="intbase" target="1.5" />
       <module name="intcustomhashmap" target="1.5" />
       <module name="inthashmap" target="1.5" />

--- a/singles/base/pom.xml
+++ b/singles/base/pom.xml
@@ -42,6 +42,10 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-base</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/Arrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/Arrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/BidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/BidirectionalIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/Function.class</include>
                                         <include>it/unimi/dsi/fastutil/Function$*.class</include>
                                         <include>it/unimi/dsi/fastutil/Hash.class</include>
@@ -50,18 +54,36 @@
                                         <include>it/unimi/dsi/fastutil/HashCommon$*.class</include>
                                         <include>it/unimi/dsi/fastutil/SafeMath.class</include>
                                         <include>it/unimi/dsi/fastutil/SafeMath$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/Swapper.class</include>
+                                        <include>it/unimi/dsi/fastutil/Swapper$*.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteConsumer.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteConsumer$*.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntComparator.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntComparator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/AbstractObjectCollection.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/AbstractObjectCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/AbstractObjectSet.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/AbstractObjectSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectBidirectionalIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/ObjectCollection.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/ObjectCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/ObjectIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/ObjectIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectSet.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectSets$*.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/ShortConsumer.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/ShortConsumer$*.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/ShortIterator.class</include>

--- a/singles/booleanbase/pom.xml
+++ b/singles/booleanbase/pom.xml
@@ -43,14 +43,36 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-booleanbase</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/booleans/AbstractBooleanCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/AbstractBooleanCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/AbstractBooleanSet.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/AbstractBooleanSet$*.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/BooleanArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/BooleanArrayList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanIterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/BooleanIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/BooleanIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanList.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/BooleanSet.class</include>
                                         <include>it/unimi/dsi/fastutil/booleans/BooleanSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/booleans/BooleanSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/bytebase/pom.xml
+++ b/singles/bytebase/pom.xml
@@ -43,20 +43,32 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-bytebase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByteCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByteCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/AbstractByteSet.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/AbstractByteSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteArrayList$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterator.class</include>
-                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterable$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteList.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteSet.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/ByteSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/bytehashmap/pom.xml
+++ b/singles/bytehashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-bytehashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/bytes/Byte2ObjectOpenHashMap$*.class</include>
                                     </includes>

--- a/singles/charbase/pom.xml
+++ b/singles/charbase/pom.xml
@@ -43,20 +43,36 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-charbase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/AbstractCharCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/AbstractCharCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/AbstractCharSet.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/AbstractCharSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/CharArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/CharArrayList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharIterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/CharIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/CharIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharList.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/CharSet.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/CharSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/CharSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/charhashmap/pom.xml
+++ b/singles/charhashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-charhashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/AbstractChar2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/chars/Char2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/Char2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/chars/Char2ObjectOpenHashMap$*.class</include>
                                     </includes>

--- a/singles/doublebase/pom.xml
+++ b/singles/doublebase/pom.xml
@@ -43,20 +43,36 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-doublebase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDoubleCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDoubleCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/AbstractDoubleSet.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/AbstractDoubleSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/DoubleArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/DoubleArrayList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleIterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/DoubleIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/DoubleIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleList.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/DoubleSet.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/DoubleSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/DoubleSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/doublehashmap/pom.xml
+++ b/singles/doublehashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-doublehashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/AbstractDouble2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/doubles/Double2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/Double2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/doubles/Double2ObjectOpenHashMap$*.class</include>
                                     </includes>

--- a/singles/floatbase/pom.xml
+++ b/singles/floatbase/pom.xml
@@ -43,20 +43,36 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-floatbase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloatCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloatCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/AbstractFloatSet.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/AbstractFloatSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/FloatArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/FloatArrayList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatIterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/FloatIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/FloatIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatList.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/FloatSet.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/FloatSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/FloatSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/floathashmap/pom.xml
+++ b/singles/floathashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-floathashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/AbstractFloat2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/floats/Float2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/Float2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/floats/Float2ObjectOpenHashMap$*.class</include>
                                     </includes>

--- a/singles/intbase/pom.xml
+++ b/singles/intbase/pom.xml
@@ -43,20 +43,34 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-intbase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractIntCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractIntCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/AbstractIntSet.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/AbstractIntSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/IntArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/IntArrayList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntIterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/IntIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/IntIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntList.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/IntSet.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/IntSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/inthashmap/pom.xml
+++ b/singles/inthashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-inthashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractInt2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/Int2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/Int2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/ints/Int2ObjectOpenHashMap$*.class</include>
                                     </includes>

--- a/singles/iobase/pom.xml
+++ b/singles/iobase/pom.xml
@@ -43,6 +43,8 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-iobase</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/io/*.class</include>
+
                                         <include>it/unimi/dsi/fastutil/*/*Arrays.class</include>
                                         <include>it/unimi/dsi/fastutil/*/*Arrays$*.class</include>
                                         <include>it/unimi/dsi/fastutil/*/*BigArrays.class</include>
@@ -55,6 +57,7 @@
                                         <include>it/unimi/dsi/fastutil/*/*Iterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/*/*Iterator.class</include>
                                         <include>it/unimi/dsi/fastutil/*/*Iterator$*.class</include>
+
                                         <include>it/unimi/dsi/fastutil/BigArrays.class</include>
                                         <include>it/unimi/dsi/fastutil/BigArrays$*.class</include>
                                         <include>it/unimi/dsi/fastutil/BigList.class</include>
@@ -65,8 +68,40 @@
                                         <include>it/unimi/dsi/fastutil/BigSwapper$*.class</include>
                                         <include>it/unimi/dsi/fastutil/Size64.class</include>
                                         <include>it/unimi/dsi/fastutil/Size64$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/io/*.class</include>
+
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractIntBigList.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/AbstractIntBigList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBigArrayBigList.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBigArrayBigList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBigList.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBigList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBigListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntBigListIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntCollection$*.class</include>
                                     </includes>
+                                    <excludes>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/bytes/ByteIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntComparator.class</include>
+                                        <include>it/unimi/dsi/fastutil/ints/IntComparator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterable$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterator$*.class</include>
+                                    </excludes>
                                 </filter>
                             </filters>
                         </configuration>

--- a/singles/longbase/pom.xml
+++ b/singles/longbase/pom.xml
@@ -43,20 +43,36 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-longbase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/AbstractLongCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/AbstractLongCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/AbstractLongSet.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/AbstractLongSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/LongArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/LongArrayList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongIterable$*.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/LongIterator.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/LongIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongList.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/LongSet.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/LongSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/LongSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/longhashmap/pom.xml
+++ b/singles/longhashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-longhashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/AbstractLong2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/longs/Long2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/Long2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/longs/Long2ObjectOpenHashMap$*.class</include>
                                     </includes>

--- a/singles/objectbase/pom.xml
+++ b/singles/objectbase/pom.xml
@@ -43,20 +43,20 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-objectbase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectMap$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/AbstractObjectSet.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/AbstractObjectSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/ObjectArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/ObjectArrayList$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterator.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterator$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/ObjectSet.class</include>
-                                        <include>it/unimi/dsi/fastutil/objects/ObjectSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectConsumer.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectConsumer$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectList.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectListIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/ObjectSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/objecthashmap/pom.xml
+++ b/singles/objecthashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-objecthashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/AbstractObject2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/objects/Object2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMap$*.class</include>
                                     </includes>

--- a/singles/shortbase/pom.xml
+++ b/singles/shortbase/pom.xml
@@ -43,20 +43,32 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-shortbase</artifact>
                                     <includes>
-                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectFunction.class</include>
-                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectFunction$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShortCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShortCollection$*.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/AbstractShortSet.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/AbstractShortSet$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectMap.class</include>
-                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectMap$*.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/ShortArrayList.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/ShortArrayList$*.class</include>
-                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterator.class</include>
-                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortArrays.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortArrays$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortBidirectionalIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortBidirectionalIterator$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortCollection.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortCollection$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortCollections.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortCollections$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterable.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterable$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterators.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortIterators$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortList.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortList$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortListIterator.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortListIterator$*.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/ShortSet.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/ShortSet$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortSets.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/ShortSets$*.class</include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/singles/shorthashmap/pom.xml
+++ b/singles/shorthashmap/pom.xml
@@ -42,6 +42,18 @@
                                 <filter>
                                     <artifact>co.aikar:fastutil-shorthashmap</artifact>
                                     <includes>
+                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/AbstractShort2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectFunction.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectFunction$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectFunctions.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectFunctions$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectMap.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectMap$*.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectMaps.class</include>
+                                        <include>it/unimi/dsi/fastutil/shorts/Short2ObjectMaps$*.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/Short2ObjectOpenHashMap.class</include>
                                         <include>it/unimi/dsi/fastutil/shorts/Short2ObjectOpenHashMap$*.class</include>
                                     </includes>


### PR DESCRIPTION
We're missing a lot of classes from the compiled jars with the new update, which causes all sorts of fun exceptions.

I went through every class by hand and included/excluded the ones we need/don't need respectively.